### PR TITLE
Added Terraria v1.3.4 packets

### DIFF
--- a/Multiplicity.Packets/CrystalInvasionSendWaitTime.cs
+++ b/Multiplicity.Packets/CrystalInvasionSendWaitTime.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+
+namespace Multiplicity.Packets
+{
+	/// <summary>
+	/// The CrystalInvasionSendWaitTime (74) packet.
+	/// </summary>
+	public class CrystalInvasionSendWaitTime : TerrariaPacket
+	{
+		public int NextWaveTime { get; set; }
+
+		public CrystalInvasionSendWaitTime()
+			: base((byte)PacketTypes.CrystalInvasionSendWaitTime)
+		{
+
+		}
+
+		public CrystalInvasionSendWaitTime(BinaryReader br)
+			: base(br)
+		{
+			NextWaveTime = br.ReadInt32();
+		}
+
+		public override string ToString()
+		{
+			return $"[CrystalInvasionSendWaitTime: NextWaveTime = {NextWaveTime}]";
+		}
+
+		#region implemented abstract members of TerrariaPacket
+
+		public override short GetLength()
+		{
+			return (short)(4);
+		}
+
+		public override void ToStream(Stream stream, bool includeHeader = true)
+		{
+			/*
+             * Length and ID headers get written in the base packet class.
+             */
+			if (includeHeader) {
+				base.ToStream(stream, includeHeader);
+			}
+
+			/*
+             * Always make sure to not close the stream when serializing.
+             * 
+             * It is up to the caller to decide if the underlying stream
+             * gets closed.  If this is a network stream we do not want
+             * the regressions of unconditionally closing the TCP socket
+             * once the payload of data has been sent to the client.
+             */
+			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
+				br.Write(NextWaveTime);
+			}
+		}
+
+		#endregion
+	}
+}

--- a/Multiplicity.Packets/CrystalInvasionSendWaitTime.cs
+++ b/Multiplicity.Packets/CrystalInvasionSendWaitTime.cs
@@ -2,47 +2,48 @@
 
 namespace Multiplicity.Packets
 {
-	/// <summary>
-	/// The CrystalInvasionSendWaitTime (74) packet.
-	/// </summary>
-	public class CrystalInvasionSendWaitTime : TerrariaPacket
-	{
-		public int NextWaveTime { get; set; }
+    /// <summary>
+    /// The CrystalInvasionSendWaitTime (74) packet.
+    /// </summary>
+    public class CrystalInvasionSendWaitTime : TerrariaPacket
+    {
+        public int NextWaveTime { get; set; }
 
-		public CrystalInvasionSendWaitTime()
-			: base((byte)PacketTypes.CrystalInvasionSendWaitTime)
-		{
+        public CrystalInvasionSendWaitTime()
+            : base((byte)PacketTypes.CrystalInvasionSendWaitTime)
+        {
 
-		}
+        }
 
-		public CrystalInvasionSendWaitTime(BinaryReader br)
-			: base(br)
-		{
-			NextWaveTime = br.ReadInt32();
-		}
+        public CrystalInvasionSendWaitTime(BinaryReader br)
+            : base(br)
+        {
+            NextWaveTime = br.ReadInt32();
+        }
 
-		public override string ToString()
-		{
-			return $"[CrystalInvasionSendWaitTime: NextWaveTime = {NextWaveTime}]";
-		}
+        public override string ToString()
+        {
+            return $"[CrystalInvasionSendWaitTime: NextWaveTime = {NextWaveTime}]";
+        }
 
-		#region implemented abstract members of TerrariaPacket
+        #region implemented abstract members of TerrariaPacket
 
-		public override short GetLength()
-		{
-			return (short)(4);
-		}
+        public override short GetLength()
+        {
+            return (short)(4);
+        }
 
-		public override void ToStream(Stream stream, bool includeHeader = true)
-		{
-			/*
+        public override void ToStream(Stream stream, bool includeHeader = true)
+        {
+            /*
              * Length and ID headers get written in the base packet class.
              */
-			if (includeHeader) {
-				base.ToStream(stream, includeHeader);
-			}
+            if (includeHeader)
+            {
+                base.ToStream(stream, includeHeader);
+            }
 
-			/*
+            /*
              * Always make sure to not close the stream when serializing.
              * 
              * It is up to the caller to decide if the underlying stream
@@ -50,11 +51,12 @@ namespace Multiplicity.Packets
              * the regressions of unconditionally closing the TCP socket
              * once the payload of data has been sent to the client.
              */
-			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
-				br.Write(NextWaveTime);
-			}
-		}
+            using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true))
+            {
+                br.Write(NextWaveTime);
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Multiplicity.Packets/CrystalInvasionStart.cs
+++ b/Multiplicity.Packets/CrystalInvasionStart.cs
@@ -2,57 +2,58 @@
 
 namespace Multiplicity.Packets
 {
-	/// <summary>
-	/// The CrystalInvasionStart (71) packet.
-	/// </summary>
-	public class CrystalInvasionStart : TerrariaPacket
-	{
-		public short X { get; set; }
+    /// <summary>
+    /// The CrystalInvasionStart (71) packet.
+    /// </summary>
+    public class CrystalInvasionStart : TerrariaPacket
+    {
+        public short X { get; set; }
 
-		public short Y { get; set; }
+        public short Y { get; set; }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
-		/// </summary>
-		public CrystalInvasionStart()
-			: base((byte)PacketTypes.CrystalInvasionStart)
-		{
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
+        /// </summary>
+        public CrystalInvasionStart()
+            : base((byte)PacketTypes.CrystalInvasionStart)
+        {
 
-		}
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
-		/// </summary>
-		/// <param name="br">br</param>
-		public CrystalInvasionStart(BinaryReader br)
-			:base(br)
-		{
-			X = br.ReadInt16();
-			Y = br.ReadInt16();
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
+        /// </summary>
+        /// <param name="br">br</param>
+        public CrystalInvasionStart(BinaryReader br)
+            : base(br)
+        {
+            X = br.ReadInt16();
+            Y = br.ReadInt16();
+        }
 
-		public override string ToString()
-		{
-			return $"[CrystalInvasionStart: X = {X} Y = {Y}]";
-		}
+        public override string ToString()
+        {
+            return $"[CrystalInvasionStart: X = {X} Y = {Y}]";
+        }
 
-		#region implemented abstract members of TerrariaPacket
+        #region implemented abstract members of TerrariaPacket
 
-		public override short GetLength()
-		{
-			return (short)(4);
-		}
+        public override short GetLength()
+        {
+            return (short)(4);
+        }
 
-		public override void ToStream(Stream stream, bool includeHeader = true)
-		{
-			/*
+        public override void ToStream(Stream stream, bool includeHeader = true)
+        {
+            /*
              * Length and ID headers get written in the base packet class.
              */
-			if (includeHeader) {
-				base.ToStream(stream, includeHeader);
-			}
+            if (includeHeader)
+            {
+                base.ToStream(stream, includeHeader);
+            }
 
-			/*
+            /*
              * Always make sure to not close the stream when serializing.
              * 
              * It is up to the caller to decide if the underlying stream
@@ -60,12 +61,13 @@ namespace Multiplicity.Packets
              * the regressions of unconditionally closing the TCP socket
              * once the payload of data has been sent to the client.
              */
-			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
-				br.Write(X);
-				br.Write(Y);
-			}
-		}
+            using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true))
+            {
+                br.Write(X);
+                br.Write(Y);
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Multiplicity.Packets/CrystalInvasionStart.cs
+++ b/Multiplicity.Packets/CrystalInvasionStart.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace Multiplicity.Packets
+{
+	/// <summary>
+	/// The CrystalInvasionStart () packet.
+	/// </summary>
+	public class CrystalInvasionStart : TerrariaPacket
+	{
+		public short X { get; set; }
+
+		public short Y { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
+		/// </summary>
+		public CrystalInvasionStart()
+			: base((byte)PacketTypes.CrystalInvasionStart)
+		{
+
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
+		/// </summary>
+		/// <param name="br">br</param>
+		public CrystalInvasionStart(BinaryReader br)
+			:base(br)
+		{
+			X = br.ReadInt16();
+			Y = br.ReadInt16();
+		}
+
+		public override string ToString()
+		{
+			return $"[CrystalInvasionStart: X = {X} Y = {Y}]";
+		}
+
+		#region implemented abstract members of TerrariaPacket
+
+		public override short GetLength()
+		{
+			return (short)(4);
+		}
+
+		public override void ToStream(Stream stream, bool includeHeader = true)
+		{
+			/*
+             * Length and ID headers get written in the base packet class.
+             */
+			if (includeHeader) {
+				base.ToStream(stream, includeHeader);
+			}
+
+			/*
+             * Always make sure to not close the stream when serializing.
+             * 
+             * It is up to the caller to decide if the underlying stream
+             * gets closed.  If this is a network stream we do not want
+             * the regressions of unconditionally closing the TCP socket
+             * once the payload of data has been sent to the client.
+             */
+			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
+				br.Write(X);
+				br.Write(Y);
+			}
+		}
+
+		#endregion
+	}
+}

--- a/Multiplicity.Packets/CrystalInvasionWipeAll.cs
+++ b/Multiplicity.Packets/CrystalInvasionWipeAll.cs
@@ -3,44 +3,39 @@
 namespace Multiplicity.Packets
 {
 	/// <summary>
-	/// The CrystalInvasionStart (71) packet.
+	/// The CrystalInvasionWipeAll (72) packet.
 	/// </summary>
-	public class CrystalInvasionStart : TerrariaPacket
+	public class CrystalInvasionWipeAll : TerrariaPacket
 	{
-		public short X { get; set; }
-
-		public short Y { get; set; }
-
 		/// <summary>
-		/// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
+		/// Initializes a new instance of the <see cref="CrystalInvasionWipeAll"/> class.
 		/// </summary>
-		public CrystalInvasionStart()
-			: base((byte)PacketTypes.CrystalInvasionStart)
+		public CrystalInvasionWipeAll()
+			: base((byte)PacketTypes.CrytsalInvasionWipeAll)
 		{
 
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="CrystalInvasionStart"/> class.
+		/// Initializes a new instance of the <see cref="CrystalInvasionWipeAll"/> class.
 		/// </summary>
 		/// <param name="br">br</param>
-		public CrystalInvasionStart(BinaryReader br)
-			:base(br)
+		public CrystalInvasionWipeAll(BinaryReader br)
+			: base(br)
 		{
-			X = br.ReadInt16();
-			Y = br.ReadInt16();
+
 		}
 
 		public override string ToString()
 		{
-			return $"[CrystalInvasionStart: X = {X} Y = {Y}]";
+			return $"[CrystalInvaionWipeAll]";
 		}
 
 		#region implemented abstract members of TerrariaPacket
 
 		public override short GetLength()
 		{
-			return (short)(4);
+			return (short)(0);
 		}
 
 		public override void ToStream(Stream stream, bool includeHeader = true)
@@ -61,8 +56,6 @@ namespace Multiplicity.Packets
              * once the payload of data has been sent to the client.
              */
 			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
-				br.Write(X);
-				br.Write(Y);
 			}
 		}
 

--- a/Multiplicity.Packets/CrystalInvasionWipeAll.cs
+++ b/Multiplicity.Packets/CrystalInvasionWipeAll.cs
@@ -2,52 +2,53 @@
 
 namespace Multiplicity.Packets
 {
-	/// <summary>
-	/// The CrystalInvasionWipeAll (72) packet.
-	/// </summary>
-	public class CrystalInvasionWipeAll : TerrariaPacket
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="CrystalInvasionWipeAll"/> class.
-		/// </summary>
-		public CrystalInvasionWipeAll()
-			: base((byte)PacketTypes.CrystalInvasionWipeAll)
-		{
+    /// <summary>
+    /// The CrystalInvasionWipeAll (72) packet.
+    /// </summary>
+    public class CrystalInvasionWipeAll : TerrariaPacket
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrystalInvasionWipeAll"/> class.
+        /// </summary>
+        public CrystalInvasionWipeAll()
+            : base((byte)PacketTypes.CrystalInvasionWipeAll)
+        {
 
-		}
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="CrystalInvasionWipeAll"/> class.
-		/// </summary>
-		/// <param name="br">br</param>
-		public CrystalInvasionWipeAll(BinaryReader br)
-			: base(br)
-		{
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrystalInvasionWipeAll"/> class.
+        /// </summary>
+        /// <param name="br">br</param>
+        public CrystalInvasionWipeAll(BinaryReader br)
+            : base(br)
+        {
 
-		}
+        }
 
-		public override string ToString()
-		{
-			return $"[CrystalInvaionWipeAll]";
-		}
+        public override string ToString()
+        {
+            return $"[CrystalInvaionWipeAll]";
+        }
 
-		#region implemented abstract members of TerrariaPacket
+        #region implemented abstract members of TerrariaPacket
 
-		public override short GetLength()
-		{
-			return (short)(0);
-		}
+        public override short GetLength()
+        {
+            return (short)(0);
+        }
 
-		public override void ToStream(Stream stream, bool includeHeader = true)
-		{
-			/*
+        public override void ToStream(Stream stream, bool includeHeader = true)
+        {
+            /*
              * Length and ID headers get written in the base packet class.
              */
-			if (includeHeader) {
-				base.ToStream(stream, includeHeader);
-			}
+            if (includeHeader)
+            {
+                base.ToStream(stream, includeHeader);
+            }
 
-			/*
+            /*
              * Always make sure to not close the stream when serializing.
              * 
              * It is up to the caller to decide if the underlying stream
@@ -55,10 +56,11 @@ namespace Multiplicity.Packets
              * the regressions of unconditionally closing the TCP socket
              * once the payload of data has been sent to the client.
              */
-			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
-			}
-		}
+            using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true))
+            {
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Multiplicity.Packets/CrystalInvasionWipeAll.cs
+++ b/Multiplicity.Packets/CrystalInvasionWipeAll.cs
@@ -11,7 +11,7 @@ namespace Multiplicity.Packets
 		/// Initializes a new instance of the <see cref="CrystalInvasionWipeAll"/> class.
 		/// </summary>
 		public CrystalInvasionWipeAll()
-			: base((byte)PacketTypes.CrytsalInvasionWipeAll)
+			: base((byte)PacketTypes.CrystalInvasionWipeAll)
 		{
 
 		}

--- a/Multiplicity.Packets/Extensions/Byte.Extensions.cs
+++ b/Multiplicity.Packets/Extensions/Byte.Extensions.cs
@@ -8,6 +8,18 @@ namespace Multiplicity.Packets.Extensions
 {
     public static class ByteExtensions
     {
+        public static byte SetBit(this byte b, int bit, bool value)
+        {
+            if (value)
+            {
+                return b = (byte)(b | (1 << bit));
+            }
+            else
+            {
+                return b = (byte)(b & ~(1 << bit));
+            }
+        }
+
         public static bool ReadBit(this byte b, int bit)
         {
             return (b & (1 << bit)) != 0;

--- a/Multiplicity.Packets/Extensions/Byte.Extensions.cs
+++ b/Multiplicity.Packets/Extensions/Byte.Extensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Multiplicity.Packets.Extensions
+{
+    public static class ByteExtensions
+    {
+        public static bool ReadBit(this byte b, int bit)
+        {
+            return (b & (1 << bit)) != 0;
+        }
+    }
+}

--- a/Multiplicity.Packets/MinionAttackTargetUpdate.cs
+++ b/Multiplicity.Packets/MinionAttackTargetUpdate.cs
@@ -1,0 +1,71 @@
+﻿using System.IO;
+
+namespace Multiplicity.Packets
+{
+	/// <summary>
+	/// The MinionAttackTargetUpdate (73) packet.
+	/// </summary>
+	public class MinionAttackTargetUpdate : TerrariaPacket
+	{
+		public byte PlayerId { get; set; }
+
+		public short MinionAttackTarget { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MinionAttackTargetUpdate"/> class.
+		/// </summary>
+		public MinionAttackTargetUpdate()
+			: base((byte)PacketTypes.MinionAttackTargetUpdate)
+		{
+
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MinionAttackTargetUpdate"/> class.
+		/// </summary>
+		/// <param name="br">br</param>
+		public MinionAttackTargetUpdate(BinaryReader br)
+			: base(br)
+		{
+			PlayerId = br.ReadByte();
+			MinionAttackTarget = br.ReadInt16();
+		}
+
+		public override string ToString()
+		{
+			return $"[MinionAttackTargetUpdate: PlayerId = {PlayerId} MinionAttackTarget = {MinionAttackTarget}]";
+		}
+
+		#region implemented abstract members of TerrariaPacket
+
+		public override short GetLength()
+		{
+			return (short)(3);
+		}
+
+		public override void ToStream(Stream stream, bool includeHeader = true)
+		{
+			/*
+             * Length and ID headers get written in the base packet class.
+             */
+			if (includeHeader) {
+				base.ToStream(stream, includeHeader);
+			}
+
+			/*
+             * Always make sure to not close the stream when serializing.
+             * 
+             * It is up to the caller to decide if the underlying stream
+             * gets closed.  If this is a network stream we do not want
+             * the regressions of unconditionally closing the TCP socket
+             * once the payload of data has been sent to the client.
+             */
+			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
+				br.Write(PlayerId);
+				br.Write(MinionAttackTarget);
+			}
+		}
+
+		#endregion
+	}
+}

--- a/Multiplicity.Packets/MinionAttackTargetUpdate.cs
+++ b/Multiplicity.Packets/MinionAttackTargetUpdate.cs
@@ -2,57 +2,58 @@
 
 namespace Multiplicity.Packets
 {
-	/// <summary>
-	/// The MinionAttackTargetUpdate (73) packet.
-	/// </summary>
-	public class MinionAttackTargetUpdate : TerrariaPacket
-	{
-		public byte PlayerId { get; set; }
+    /// <summary>
+    /// The MinionAttackTargetUpdate (73) packet.
+    /// </summary>
+    public class MinionAttackTargetUpdate : TerrariaPacket
+    {
+        public byte PlayerId { get; set; }
 
-		public short MinionAttackTarget { get; set; }
+        public short MinionAttackTarget { get; set; }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MinionAttackTargetUpdate"/> class.
-		/// </summary>
-		public MinionAttackTargetUpdate()
-			: base((byte)PacketTypes.MinionAttackTargetUpdate)
-		{
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MinionAttackTargetUpdate"/> class.
+        /// </summary>
+        public MinionAttackTargetUpdate()
+            : base((byte)PacketTypes.MinionAttackTargetUpdate)
+        {
 
-		}
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MinionAttackTargetUpdate"/> class.
-		/// </summary>
-		/// <param name="br">br</param>
-		public MinionAttackTargetUpdate(BinaryReader br)
-			: base(br)
-		{
-			PlayerId = br.ReadByte();
-			MinionAttackTarget = br.ReadInt16();
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MinionAttackTargetUpdate"/> class.
+        /// </summary>
+        /// <param name="br">br</param>
+        public MinionAttackTargetUpdate(BinaryReader br)
+            : base(br)
+        {
+            PlayerId = br.ReadByte();
+            MinionAttackTarget = br.ReadInt16();
+        }
 
-		public override string ToString()
-		{
-			return $"[MinionAttackTargetUpdate: PlayerId = {PlayerId} MinionAttackTarget = {MinionAttackTarget}]";
-		}
+        public override string ToString()
+        {
+            return $"[MinionAttackTargetUpdate: PlayerId = {PlayerId} MinionAttackTarget = {MinionAttackTarget}]";
+        }
 
-		#region implemented abstract members of TerrariaPacket
+        #region implemented abstract members of TerrariaPacket
 
-		public override short GetLength()
-		{
-			return (short)(3);
-		}
+        public override short GetLength()
+        {
+            return (short)(3);
+        }
 
-		public override void ToStream(Stream stream, bool includeHeader = true)
-		{
-			/*
+        public override void ToStream(Stream stream, bool includeHeader = true)
+        {
+            /*
              * Length and ID headers get written in the base packet class.
              */
-			if (includeHeader) {
-				base.ToStream(stream, includeHeader);
-			}
+            if (includeHeader)
+            {
+                base.ToStream(stream, includeHeader);
+            }
 
-			/*
+            /*
              * Always make sure to not close the stream when serializing.
              * 
              * It is up to the caller to decide if the underlying stream
@@ -60,12 +61,13 @@ namespace Multiplicity.Packets
              * the regressions of unconditionally closing the TCP socket
              * once the payload of data has been sent to the client.
              */
-			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
-				br.Write(PlayerId);
-				br.Write(MinionAttackTarget);
-			}
-		}
+            using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true))
+            {
+                br.Write(PlayerId);
+                br.Write(MinionAttackTarget);
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Multiplicity.Packets/Multiplicity.Packets.csproj
+++ b/Multiplicity.Packets/Multiplicity.Packets.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CrystalInvasionStart.cs" />
+    <Compile Include="CrystalInvasionWipeAll.cs" />
     <Compile Include="Deprecated.cs" />
     <Compile Include="Models\Tile.cs" />
     <Compile Include="AlterItemDrop.cs" />

--- a/Multiplicity.Packets/Multiplicity.Packets.csproj
+++ b/Multiplicity.Packets/Multiplicity.Packets.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Null.cs" />
     <Compile Include="PlaceChest.cs" />
     <Compile Include="Placeholder.cs" />
+    <Compile Include="PlayerHurtV2.cs" />
     <Compile Include="ProjectileUpdate.cs" />
     <Compile Include="ReleaseNPC.cs" />
     <Compile Include="SetChestName.cs" />

--- a/Multiplicity.Packets/Multiplicity.Packets.csproj
+++ b/Multiplicity.Packets/Multiplicity.Packets.csproj
@@ -37,6 +37,7 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CrystalInvasionStart.cs" />
     <Compile Include="Deprecated.cs" />
     <Compile Include="Models\Tile.cs" />
     <Compile Include="AlterItemDrop.cs" />

--- a/Multiplicity.Packets/Multiplicity.Packets.csproj
+++ b/Multiplicity.Packets/Multiplicity.Packets.csproj
@@ -40,6 +40,7 @@
     <Compile Include="CrystalInvasionStart.cs" />
     <Compile Include="CrystalInvasionWipeAll.cs" />
     <Compile Include="Deprecated.cs" />
+    <Compile Include="MinionAttackTargetUpdate.cs" />
     <Compile Include="Models\Tile.cs" />
     <Compile Include="AlterItemDrop.cs" />
     <Compile Include="GetChestName.cs" />

--- a/Multiplicity.Packets/Multiplicity.Packets.csproj
+++ b/Multiplicity.Packets/Multiplicity.Packets.csproj
@@ -37,6 +37,7 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CrystalInvasionSendWaitTime.cs" />
     <Compile Include="CrystalInvasionStart.cs" />
     <Compile Include="CrystalInvasionWipeAll.cs" />
     <Compile Include="Deprecated.cs" />

--- a/Multiplicity.Packets/Multiplicity.Packets.csproj
+++ b/Multiplicity.Packets/Multiplicity.Packets.csproj
@@ -41,6 +41,7 @@
     <Compile Include="CrystalInvasionStart.cs" />
     <Compile Include="CrystalInvasionWipeAll.cs" />
     <Compile Include="Deprecated.cs" />
+    <Compile Include="Extensions\Byte.Extensions.cs" />
     <Compile Include="MinionAttackTargetUpdate.cs" />
     <Compile Include="Models\Tile.cs" />
     <Compile Include="AlterItemDrop.cs" />
@@ -166,5 +167,4 @@
     <Compile Include="PacketTypes.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup />
 </Project>

--- a/Multiplicity.Packets/Multiplicity.Packets.csproj
+++ b/Multiplicity.Packets/Multiplicity.Packets.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Null.cs" />
     <Compile Include="PlaceChest.cs" />
     <Compile Include="Placeholder.cs" />
+    <Compile Include="PlayerDeathV2.cs" />
     <Compile Include="PlayerHurtV2.cs" />
     <Compile Include="ProjectileUpdate.cs" />
     <Compile Include="ReleaseNPC.cs" />

--- a/Multiplicity.Packets/PacketTypes.cs
+++ b/Multiplicity.Packets/PacketTypes.cs
@@ -113,7 +113,13 @@
 		/*109*/ MassWireOperation,
 		/*110*/ MassWireOperationConsume,
 		/*111*/ ToggleBirthdayParty,
-		/*112*/ GrowFX
+		/*112*/ GrowFX,
+		/*113*/ CrystalInvasionStart,
+		/*114*/ CrytsalInvasionWipeAll,
+		/*115*/ MinionAttackTargetUpdate,
+		/*116*/ CrystalInvasionSendWaitTime,
+		/*117*/ PlayerHurtV2,
+		/*118*/ PlayerDeathV2
     }
 }
 

--- a/Multiplicity.Packets/PacketTypes.cs
+++ b/Multiplicity.Packets/PacketTypes.cs
@@ -115,7 +115,7 @@
 		/*111*/ ToggleBirthdayParty,
 		/*112*/ GrowFX,
 		/*113*/ CrystalInvasionStart,
-		/*114*/ CrytsalInvasionWipeAll,
+		/*114*/ CrystalInvasionWipeAll,
 		/*115*/ MinionAttackTargetUpdate,
 		/*116*/ CrystalInvasionSendWaitTime,
 		/*117*/ PlayerHurtV2,

--- a/Multiplicity.Packets/PlayerDeathV2.cs
+++ b/Multiplicity.Packets/PlayerDeathV2.cs
@@ -3,9 +3,9 @@
 namespace Multiplicity.Packets
 {
 	/// <summary>
-	/// The PlayerHurtV2 (75) packet.
+	/// The PlayerDeathV2 (76) packet.
 	/// </summary>
-	public class PlayerHurtV2 : TerrariaPacket
+	public class PlayerDeathV2 : TerrariaPacket
 	{
 		public byte PlayerId { get; set; }
 
@@ -58,17 +58,15 @@ namespace Multiplicity.Packets
 		public byte HitDirection { get; set; }
 
 		/// <summary>
-		/// BitFlags: 1 = Crit, 2 = PvP
+		/// BitFlags: 1 = PvP
 		/// </summary>
 		public byte Flags { get; set; }
-
-		public byte CooldownCounter { get; set; }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
 		/// </summary>
-		public PlayerHurtV2()
-			: base((byte)PacketTypes.PlayerHurtV2)
+		public PlayerDeathV2()
+			: base((byte)PacketTypes.PlayerDeathV2)
 		{
 
 		}
@@ -77,7 +75,7 @@ namespace Multiplicity.Packets
 		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
 		/// </summary>
 		/// <param name="br">br</param>
-		public PlayerHurtV2(BinaryReader br)
+		public PlayerDeathV2(BinaryReader br)
 			: base (br)
 		{
 			PlayerId = br.ReadByte();
@@ -92,20 +90,19 @@ namespace Multiplicity.Packets
 			Damage = br.ReadInt16();
 			HitDirection = br.ReadByte();
 			Flags = br.ReadByte();
-			CooldownCounter = br.ReadByte();
 		}
 
 		public override string ToString()
 		{
-			return 
-				$"[PlayerHurtV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags} CooldownCounter = {CooldownCounter}]";
+			return
+				$"[PlayerDeathV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags}]";
 		}
 
 		#region implemented abstract members of TerrariaPacket
 
 		public override short GetLength()
 		{
-			return (short)(19);
+			return (short)(18);
 		}
 
 		public override void ToStream(Stream stream, bool includeHeader = true)
@@ -138,7 +135,6 @@ namespace Multiplicity.Packets
 				br.Write(Damage);
 				br.Write(HitDirection);
 				br.Write(Flags);
-				br.Write(CooldownCounter);
 			}
 		}
 

--- a/Multiplicity.Packets/PlayerDeathV2.cs
+++ b/Multiplicity.Packets/PlayerDeathV2.cs
@@ -8,7 +8,7 @@ namespace Multiplicity.Packets
     /// </summary>
     public class PlayerDeathV2 : TerrariaPacket
     {
-        private int _length;
+        private int _packetLength;
 
         public byte PlayerId { get; set; }
 
@@ -21,17 +21,17 @@ namespace Multiplicity.Packets
         /// <summary>
         /// Only in PvP.
         /// </summary>
-        public short FromPlayerIndex { get; set; }
+        public short FromPlayerIndex { get; set; } = -1;
 
         /// <summary>
         /// Only if hurt by an npc.
         /// </summary>
-        public short FromNpcIndex { get; set; }
+        public short FromNpcIndex { get; set; } = -1;
 
         /// <summary>
         /// Only in PvP.
         /// </summary>
-        public short FromProjectileIndex { get; set; }
+        public short FromProjectileIndex { get; set; } = -1;
 
         /// <summary>
         /// 0 = Fall damage, 1 = Drowning, 2 = Lava damage, 3 = Fall damage, 4 = Demon Altar,
@@ -39,7 +39,7 @@ namespace Multiplicity.Packets
         /// 10 = Electrified, 11 = WoF (escaped), 12 = WoF (licked), 13 = Chaos State,
         /// 14 = Chaos State V2 (male), 15 = Chaos State V2 (female)
         /// </summary>
-        public byte FromOther { get; set; }
+        public byte FromOther { get; set; } = 254;
 
         /// <summary>
         /// Only in PvP.
@@ -89,25 +89,25 @@ namespace Multiplicity.Packets
             if (PlayerDeathReason.ReadBit(0))
             {
                 FromPlayerIndex = br.ReadInt16();
-                _length += 2;
+                _packetLength += 2;
             }
 
             if (PlayerDeathReason.ReadBit(1))
             {
                 FromNpcIndex = br.ReadInt16();
-                _length += 2;
+                _packetLength += 2;
             }
 
             if (PlayerDeathReason.ReadBit(2))
             {
                 FromProjectileIndex = br.ReadInt16();
-                _length += 2;
+                _packetLength += 2;
             }
 
             if (PlayerDeathReason.ReadBit(3))
             {
                 FromOther = br.ReadByte();
-                _length += 1;
+                _packetLength += 1;
             }
 
             if (PlayerDeathReason.ReadBit(4))
@@ -119,19 +119,19 @@ namespace Multiplicity.Packets
             if (PlayerDeathReason.ReadBit(5))
             {
                 FromItemType = br.ReadInt16();
-                _length += 2;
+                _packetLength += 2;
             }
 
             if (PlayerDeathReason.ReadBit(6))
             {
                 FromItemPrefix = br.ReadByte();
-                _length += 1;
+                _packetLength += 1;
             }
 
             if (PlayerDeathReason.ReadBit(7))
             {
                 FromCustomReason = br.ReadString();
-                _length += FromCustomReason.Length;
+                _packetLength += FromCustomReason.Length;
             }
 
             Damage = br.ReadInt16();
@@ -172,13 +172,55 @@ namespace Multiplicity.Packets
             using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
                 br.Write(PlayerId);
                 br.Write(PlayerDeathReason);
-                br.Write(FromPlayerIndex);
-                br.Write(FromNpcIndex);
-                br.Write(FromProjectileIndex);
-                br.Write(FromOther);
-                br.Write(FromProjectileType);
-                br.Write(FromItemType);
-                br.Write(FromItemPrefix);
+
+                if (FromPlayerIndex != -1)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(0, true);
+                    br.Write(FromPlayerIndex);
+                }
+
+                if (FromNpcIndex != -1)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(1, true);
+                    br.Write(FromNpcIndex);
+                }
+
+                if (FromProjectileIndex != -1)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(2, true);
+                    br.Write(FromProjectileIndex);
+                }
+
+                if (FromOther != 254)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(3, true);
+                    br.Write(FromOther);
+                }
+
+                if (FromProjectileType != 0)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(4, true);
+                    br.Write(FromProjectileType);
+                }
+
+                if (FromItemType != 0)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(5, true);
+                    br.Write(FromItemType);
+                }
+
+                if (FromItemPrefix != 0)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(6, true);
+                    br.Write(FromItemPrefix);
+                }
+
+                if (FromCustomReason != null)
+                {
+                    PlayerDeathReason = PlayerDeathReason.SetBit(7, true);
+                    br.Write(FromCustomReason);
+                }
+
                 br.Write(Damage);
                 br.Write(HitDirection);
                 br.Write(Flags);

--- a/Multiplicity.Packets/PlayerDeathV2.cs
+++ b/Multiplicity.Packets/PlayerDeathV2.cs
@@ -1,120 +1,159 @@
 ﻿using System.IO;
+using Multiplicity.Packets.Extensions;
 
 namespace Multiplicity.Packets
 {
-	/// <summary>
-	/// The PlayerDeathV2 (76) packet.
-	/// </summary>
-	public class PlayerDeathV2 : TerrariaPacket
-	{
-		public byte PlayerId { get; set; }
+    /// <summary>
+    /// The PlayerDeathV2 (76) packet.
+    /// </summary>
+    public class PlayerDeathV2 : TerrariaPacket
+    {
+        private int _length;
 
-		/// <summary>
-		/// BitFlags: 1 = From Player Index, 2 = From NPC Index, 4 = From Projectile Index
-		/// 8 = From other, 16 = From Projectile Type, 32 = From Item Type, 64 = From Item Prefix
-		/// </summary>
-		public byte PlayerDeathReason { get; set; }
+        public byte PlayerId { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromPlayerIndex { get; set; }
+        /// <summary>
+        /// BitFlags: 1 = From Player Index, 2 = From NPC Index, 4 = From Projectile Index
+        /// 8 = From other, 16 = From Projectile Type, 32 = From Item Type, 64 = From Item Prefix
+        /// </summary>
+        public byte PlayerDeathReason { get; set; }
 
-		/// <summary>
-		/// Only if hurt by an npc.
-		/// </summary>
-		public short FromNpcIndex { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromPlayerIndex { get; set; } = -1;
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromProjectileIndex { get; set; }
+        /// <summary>
+        /// Only if hurt by an npc.
+        /// </summary>
+        public short FromNpcIndex { get; set; } = -1;
 
-		/// <summary>
-		/// 0 = Fall damage, 1 = Drowning, 2 = Lava damage, 3 = Fall damage, 4 = Demon Altar,
-		/// 5 = N/A, 6 = Companion Cube, 7 = Suffocation, 8 = Burning, 9 = Poison/Venom,
-		/// 10 = Electrified, 11 = WoF (escaped), 12 = WoF (licked), 13 = Chaos State,
-		/// 14 = Chaos State V2 (male), 15 = Chaos State V2 (female)
-		/// </summary>
-		public byte FromOther { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromProjectileIndex { get; set; } = -1;
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromProjectileType { get; set; }
+        /// <summary>
+        /// 0 = Fall damage, 1 = Drowning, 2 = Lava damage, 3 = Fall damage, 4 = Demon Altar,
+        /// 5 = N/A, 6 = Companion Cube, 7 = Suffocation, 8 = Burning, 9 = Poison/Venom,
+        /// 10 = Electrified, 11 = WoF (escaped), 12 = WoF (licked), 13 = Chaos State,
+        /// 14 = Chaos State V2 (male), 15 = Chaos State V2 (female)
+        /// </summary>
+        public byte FromOther { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromItemType { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromProjectileType { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public byte FromItemPrefix { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromItemType { get; set; }
 
-		public short Damage { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public byte FromItemPrefix { get; set; }
 
-		public byte HitDirection { get; set; }
+        public short Damage { get; set; }
 
-		/// <summary>
-		/// BitFlags: 1 = PvP
-		/// </summary>
-		public byte Flags { get; set; }
+        public byte HitDirection { get; set; }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
-		/// </summary>
-		public PlayerDeathV2()
-			: base((byte)PacketTypes.PlayerDeathV2)
-		{
+        /// <summary>
+        /// BitFlags: 1 = PvP
+        /// </summary>
+        public byte Flags { get; set; }
 
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
+        /// </summary>
+        public PlayerDeathV2()
+            : base((byte)PacketTypes.PlayerDeathV2)
+        {
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
-		/// </summary>
-		/// <param name="br">br</param>
-		public PlayerDeathV2(BinaryReader br)
-			: base (br)
-		{
-			PlayerId = br.ReadByte();
-			PlayerDeathReason = br.ReadByte();
-			FromPlayerIndex = br.ReadInt16();
-			FromNpcIndex = br.ReadInt16();
-			FromProjectileIndex = br.ReadInt16();
-			FromOther = br.ReadByte();
-			FromProjectileType = br.ReadInt16();
-			FromItemType = br.ReadInt16();
-			FromItemPrefix = br.ReadByte();
-			Damage = br.ReadInt16();
-			HitDirection = br.ReadByte();
-			Flags = br.ReadByte();
-		}
+        }
 
-		public override string ToString()
-		{
-			return
-				$"[PlayerDeathV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags}]";
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
+        /// </summary>
+        /// <param name="br">br</param>
+        public PlayerDeathV2(BinaryReader br)
+            : base(br)
+        {
+            PlayerId = br.ReadByte();
+            PlayerDeathReason = br.ReadByte();
 
-		#region implemented abstract members of TerrariaPacket
+            if (PlayerDeathReason.ReadBit(0))
+            {
+                FromPlayerIndex = br.ReadInt16();
+                _length += 2;
+            }
 
-		public override short GetLength()
-		{
-			return (short)(18);
-		}
+            if (PlayerDeathReason.ReadBit(1))
+            {
+                FromNpcIndex = br.ReadInt16();
+                _length += 2;
+            }
 
-		public override void ToStream(Stream stream, bool includeHeader = true)
-		{
-			/*
+            if (PlayerDeathReason.ReadBit(2))
+            {
+                FromProjectileIndex = br.ReadInt16();
+                _length += 2;
+            }
+
+            if (PlayerDeathReason.ReadBit(3))
+            {
+                FromOther = br.ReadByte();
+                _length += 1;
+            }
+
+            if (PlayerDeathReason.ReadBit(4))
+            {
+                FromProjectileType = br.ReadInt16();
+                _length += 2;
+            }
+
+            if (PlayerDeathReason.ReadBit(5))
+            {
+                FromItemType = br.ReadInt16();
+                _length += 2;
+            }
+
+            if (PlayerDeathReason.ReadBit(6))
+            {
+                FromItemPrefix = br.ReadByte();
+                _length += 1;
+            }
+
+            Damage = br.ReadInt16();
+            HitDirection = br.ReadByte();
+            Flags = br.ReadByte();
+        }
+
+        public override string ToString()
+        {
+            return
+                $"[PlayerDeathV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags}]";
+        }
+
+        #region implemented abstract members of TerrariaPacket
+
+        public override short GetLength()
+        {
+            return (short)(6 + _length);
+        }
+
+        public override void ToStream(Stream stream, bool includeHeader = true)
+        {
+            /*
              * Length and ID headers get written in the base packet class.
              */
-			if (includeHeader) {
-				base.ToStream(stream, includeHeader);
-			}
+            if (includeHeader) {
+                base.ToStream(stream, includeHeader);
+            }
 
-			/*
+            /*
              * Always make sure to not close the stream when serializing.
              * 
              * It is up to the caller to decide if the underlying stream
@@ -122,22 +161,22 @@ namespace Multiplicity.Packets
              * the regressions of unconditionally closing the TCP socket
              * once the payload of data has been sent to the client.
              */
-			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
-				br.Write(PlayerId);
-				br.Write(PlayerDeathReason);
-				br.Write(FromPlayerIndex);
-				br.Write(FromNpcIndex);
-				br.Write(FromProjectileIndex);
-				br.Write(FromOther);
-				br.Write(FromProjectileType);
-				br.Write(FromItemType);
-				br.Write(FromItemPrefix);
-				br.Write(Damage);
-				br.Write(HitDirection);
-				br.Write(Flags);
-			}
-		}
+            using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
+                br.Write(PlayerId);
+                br.Write(PlayerDeathReason);
+                br.Write(FromPlayerIndex);
+                br.Write(FromNpcIndex);
+                br.Write(FromProjectileIndex);
+                br.Write(FromOther);
+                br.Write(FromProjectileType);
+                br.Write(FromItemType);
+                br.Write(FromItemPrefix);
+                br.Write(Damage);
+                br.Write(HitDirection);
+                br.Write(Flags);
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Multiplicity.Packets/PlayerDeathV2.cs
+++ b/Multiplicity.Packets/PlayerDeathV2.cs
@@ -21,17 +21,17 @@ namespace Multiplicity.Packets
         /// <summary>
         /// Only in PvP.
         /// </summary>
-        public short FromPlayerIndex { get; set; } = -1;
+        public short FromPlayerIndex { get; set; }
 
         /// <summary>
         /// Only if hurt by an npc.
         /// </summary>
-        public short FromNpcIndex { get; set; } = -1;
+        public short FromNpcIndex { get; set; }
 
         /// <summary>
         /// Only in PvP.
         /// </summary>
-        public short FromProjectileIndex { get; set; } = -1;
+        public short FromProjectileIndex { get; set; }
 
         /// <summary>
         /// 0 = Fall damage, 1 = Drowning, 2 = Lava damage, 3 = Fall damage, 4 = Demon Altar,
@@ -55,6 +55,8 @@ namespace Multiplicity.Packets
         /// Only in PvP.
         /// </summary>
         public byte FromItemPrefix { get; set; }
+
+        public string FromCustomReason { get; set; }
 
         public short Damage { get; set; }
 
@@ -126,6 +128,12 @@ namespace Multiplicity.Packets
                 _length += 1;
             }
 
+            if (PlayerDeathReason.ReadBit(7))
+            {
+                FromCustomReason = br.ReadString();
+                _length += FromCustomReason.Length;
+            }
+
             Damage = br.ReadInt16();
             HitDirection = br.ReadByte();
             Flags = br.ReadByte();
@@ -134,7 +142,7 @@ namespace Multiplicity.Packets
         public override string ToString()
         {
             return
-                $"[PlayerDeathV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags}]";
+                $"[PlayerDeathV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} FromCustomReason = {FromCustomReason} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags}]";
         }
 
         #region implemented abstract members of TerrariaPacket

--- a/Multiplicity.Packets/PlayerHurtV2.cs
+++ b/Multiplicity.Packets/PlayerHurtV2.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace Multiplicity.Packets
+{
+	/// <summary>
+	/// The PlayerHurtV2 (75) packet.
+	/// </summary>
+	public class PlayerHurtV2 : TerrariaPacket
+	{
+		public byte PlayerId { get; set; }
+
+		/// <summary>
+		/// BitFlags: 1 = From Player Index, 2 = From NPC Index, 4 = From Projectile Index
+		/// 8 = From other, 16 = From Projectile Type, 32 = From Item Type, 64 = From Item Prefix
+		/// </summary>
+		public byte PlayerDeathReason { get; set; }
+
+		/// <summary>
+		/// Only in PvP.
+		/// </summary>
+		public short FromPlayerIndex { get; set; }
+
+		/// <summary>
+		/// Only if hurt by an npc.
+		/// </summary>
+		public short FromNpcIndex { get; set; }
+
+		/// <summary>
+		/// Only in PvP.
+		/// </summary>
+		public short FromProjectileIndex { get; set; }
+
+		/// <summary>
+		/// 0 = Fall damage, 1 = Drowning, 2 = Lava damage, 3 = Fall damage, 4 = Demon Altar,
+		/// 5 = N/A, 6 = Companion Cube, 7 = Suffocation, 8 = Burning, 9 = Poison/Venom,
+		/// 10 = Electrified, 11 = WoF (escaped), 12 = WoF (licked), 13 = Chaos State,
+		/// 14 = Chaos State V2 (male), 15 = Chaos State V2 (female)
+		/// </summary>
+		public byte FromOther { get; set; }
+
+		/// <summary>
+		/// Only in PvP.
+		/// </summary>
+		public short FromProjectileType { get; set; }
+
+		/// <summary>
+		/// Only in PvP.
+		/// </summary>
+		public short FromItemType { get; set; }
+
+		/// <summary>
+		/// Only in PvP.
+		/// </summary>
+		public short FromItemPrefix { get; set; }
+
+		public short Damage { get; set; }
+
+		public byte HitDirection { get; set; }
+
+		/// <summary>
+		/// BitFlags: 1 = Crit, 2 = PvP
+		/// </summary>
+		public byte Flags { get; set; }
+
+		public byte CooldownCounter { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
+		/// </summary>
+		public PlayerHurtV2()
+			: base((byte)PacketTypes.PlayerHurtV2)
+		{
+
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
+		/// </summary>
+		/// <param name="br">br</param>
+		public PlayerHurtV2(BinaryReader br)
+			: base (br)
+		{
+			PlayerId = br.ReadByte();
+			PlayerDeathReason = br.ReadByte();
+			FromPlayerIndex = br.ReadInt16();
+			FromNpcIndex = br.ReadInt16();
+			FromProjectileIndex = br.ReadInt16();
+			FromOther = br.ReadByte();
+			FromProjectileType = br.ReadInt16();
+			FromItemType = br.ReadInt16();
+			FromItemPrefix = br.ReadInt16();
+			Damage = br.ReadInt16();
+			HitDirection = br.ReadByte();
+			Flags = br.ReadByte();
+			CooldownCounter = br.ReadByte();
+		}
+
+		public override string ToString()
+		{
+			return 
+				$"[PlayerHurtV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags} CooldownCounter = {CooldownCounter}]";
+		}
+
+		#region implemented abstract members of TerrariaPacket
+
+		public override short GetLength()
+		{
+			return (short)(20);
+		}
+
+		public override void ToStream(Stream stream, bool includeHeader = true)
+		{
+			/*
+             * Length and ID headers get written in the base packet class.
+             */
+			if (includeHeader) {
+				base.ToStream(stream, includeHeader);
+			}
+
+			/*
+             * Always make sure to not close the stream when serializing.
+             * 
+             * It is up to the caller to decide if the underlying stream
+             * gets closed.  If this is a network stream we do not want
+             * the regressions of unconditionally closing the TCP socket
+             * once the payload of data has been sent to the client.
+             */
+			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
+				br.Write(PlayerId);
+				br.Write(PlayerDeathReason);
+				br.Write(FromPlayerIndex);
+				br.Write(FromNpcIndex);
+				br.Write(FromProjectileIndex);
+				br.Write(FromOther);
+				br.Write(FromProjectileType);
+				br.Write(FromItemType);
+				br.Write(FromItemPrefix);
+				br.Write(Damage);
+				br.Write(HitDirection);
+				br.Write(Flags);
+				br.Write(CooldownCounter);
+			}
+		}
+
+		#endregion
+	}
+}

--- a/Multiplicity.Packets/PlayerHurtV2.cs
+++ b/Multiplicity.Packets/PlayerHurtV2.cs
@@ -56,6 +56,8 @@ namespace Multiplicity.Packets
         /// </summary>
         public byte FromItemPrefix { get; set; }
 
+        public string FromCustomReason { get; set; }
+
         public short Damage { get; set; }
 
         public byte HitDirection { get; set; }
@@ -128,6 +130,12 @@ namespace Multiplicity.Packets
                 _length += 1;
             }
 
+            if (PlayerDeathReason.ReadBit(7))
+            {
+                FromCustomReason = br.ReadString();
+                _length += FromCustomReason.Length;
+            }
+
             Damage = br.ReadInt16();
             HitDirection = br.ReadByte();
             Flags = br.ReadByte();
@@ -136,7 +144,7 @@ namespace Multiplicity.Packets
         public override string ToString()
         {
             return
-                $"[PlayerHurtV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags} CooldownCounter = {CooldownCounter}]";
+                $"[PlayerHurtV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} FromCustomReason = {FromCustomReason} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags} CooldownCounter = {CooldownCounter}]";
         }
 
         #region implemented abstract members of TerrariaPacket

--- a/Multiplicity.Packets/PlayerHurtV2.cs
+++ b/Multiplicity.Packets/PlayerHurtV2.cs
@@ -1,123 +1,161 @@
 ﻿using System.IO;
+using Multiplicity.Packets.Extensions;
 
 namespace Multiplicity.Packets
 {
-	/// <summary>
-	/// The PlayerHurtV2 (75) packet.
-	/// </summary>
-	public class PlayerHurtV2 : TerrariaPacket
-	{
-		public byte PlayerId { get; set; }
+    /// <summary>
+    /// The PlayerHurtV2 (75) packet.
+    /// </summary>
+    public class PlayerHurtV2 : TerrariaPacket
+    {
+        private int _length;
 
-		/// <summary>
-		/// BitFlags: 1 = From Player Index, 2 = From NPC Index, 4 = From Projectile Index
-		/// 8 = From other, 16 = From Projectile Type, 32 = From Item Type, 64 = From Item Prefix
-		/// </summary>
-		public byte PlayerDeathReason { get; set; }
+        public byte PlayerId { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromPlayerIndex { get; set; }
+        /// <summary>
+        /// BitFlags: 1 = From Player Index, 2 = From NPC Index, 4 = From Projectile Index
+        /// 8 = From other, 16 = From Projectile Type, 32 = From Item Type, 64 = From Item Prefix
+        /// </summary>
+        public byte PlayerDeathReason { get; set; }
 
-		/// <summary>
-		/// Only if hurt by an npc.
-		/// </summary>
-		public short FromNpcIndex { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromPlayerIndex { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromProjectileIndex { get; set; }
+        /// <summary>
+        /// Only if hurt by an npc.
+        /// </summary>
+        public short FromNpcIndex { get; set; }
 
-		/// <summary>
-		/// 0 = Fall damage, 1 = Drowning, 2 = Lava damage, 3 = Fall damage, 4 = Demon Altar,
-		/// 5 = N/A, 6 = Companion Cube, 7 = Suffocation, 8 = Burning, 9 = Poison/Venom,
-		/// 10 = Electrified, 11 = WoF (escaped), 12 = WoF (licked), 13 = Chaos State,
-		/// 14 = Chaos State V2 (male), 15 = Chaos State V2 (female)
-		/// </summary>
-		public byte FromOther { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromProjectileIndex { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromProjectileType { get; set; }
+        /// <summary>
+        /// 0 = Fall damage, 1 = Drowning, 2 = Lava damage, 3 = Fall damage, 4 = Demon Altar,
+        /// 5 = N/A, 6 = Companion Cube, 7 = Suffocation, 8 = Burning, 9 = Poison/Venom,
+        /// 10 = Electrified, 11 = WoF (escaped), 12 = WoF (licked), 13 = Chaos State,
+        /// 14 = Chaos State V2 (male), 15 = Chaos State V2 (female)
+        /// </summary>
+        public byte FromOther { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public short FromItemType { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromProjectileType { get; set; }
 
-		/// <summary>
-		/// Only in PvP.
-		/// </summary>
-		public byte FromItemPrefix { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public short FromItemType { get; set; }
 
-		public short Damage { get; set; }
+        /// <summary>
+        /// Only in PvP.
+        /// </summary>
+        public byte FromItemPrefix { get; set; }
 
-		public byte HitDirection { get; set; }
+        public short Damage { get; set; }
 
-		/// <summary>
-		/// BitFlags: 1 = Crit, 2 = PvP
-		/// </summary>
-		public byte Flags { get; set; }
+        public byte HitDirection { get; set; }
 
-		public byte CooldownCounter { get; set; }
+        /// <summary>
+        /// BitFlags: 1 = Crit, 2 = PvP
+        /// </summary>
+        public byte Flags { get; set; }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
-		/// </summary>
-		public PlayerHurtV2()
-			: base((byte)PacketTypes.PlayerHurtV2)
-		{
+        public byte CooldownCounter { get; set; }
 
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
+        /// </summary>
+        public PlayerHurtV2()
+            : base((byte)PacketTypes.PlayerHurtV2)
+        {
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
-		/// </summary>
-		/// <param name="br">br</param>
-		public PlayerHurtV2(BinaryReader br)
-			: base (br)
-		{
-			PlayerId = br.ReadByte();
-			PlayerDeathReason = br.ReadByte();
-			FromPlayerIndex = br.ReadInt16();
-			FromNpcIndex = br.ReadInt16();
-			FromProjectileIndex = br.ReadInt16();
-			FromOther = br.ReadByte();
-			FromProjectileType = br.ReadInt16();
-			FromItemType = br.ReadInt16();
-			FromItemPrefix = br.ReadByte();
-			Damage = br.ReadInt16();
-			HitDirection = br.ReadByte();
-			Flags = br.ReadByte();
-			CooldownCounter = br.ReadByte();
-		}
+        }
 
-		public override string ToString()
-		{
-			return 
-				$"[PlayerHurtV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags} CooldownCounter = {CooldownCounter}]";
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlayerHurtV2"/> class.
+        /// </summary>
+        /// <param name="br">br</param>
+        public PlayerHurtV2(BinaryReader br)
+            : base(br)
+        {
+            PlayerId = br.ReadByte();
+            PlayerDeathReason = br.ReadByte();
 
-		#region implemented abstract members of TerrariaPacket
+            if (PlayerDeathReason.ReadBit(0))
+            {
+                FromPlayerIndex = br.ReadInt16();
+                _length += 2;
+            }
 
-		public override short GetLength()
-		{
-			return (short)(19);
-		}
+            if (PlayerDeathReason.ReadBit(1))
+            {
+                FromNpcIndex = br.ReadInt16();
+                _length += 2;
+            }
 
-		public override void ToStream(Stream stream, bool includeHeader = true)
-		{
-			/*
+            if (PlayerDeathReason.ReadBit(2))
+            {
+                FromProjectileIndex = br.ReadInt16();
+                _length += 2;
+            }
+
+            if (PlayerDeathReason.ReadBit(3))
+            {
+                FromOther = br.ReadByte();
+                _length += 1;
+            }
+
+            if (PlayerDeathReason.ReadBit(4))
+            {
+                FromProjectileType = br.ReadInt16();
+                _length += 2;
+            }
+
+            if (PlayerDeathReason.ReadBit(5))
+            {
+                FromItemType = br.ReadInt16();
+                _length += 2;
+            }
+
+            if (PlayerDeathReason.ReadBit(6))
+            {
+                FromItemPrefix = br.ReadByte();
+                _length += 1;
+            }
+
+            Damage = br.ReadInt16();
+            HitDirection = br.ReadByte();
+            Flags = br.ReadByte();
+        }
+
+        public override string ToString()
+        {
+            return
+                $"[PlayerHurtV2: PlayerId = {PlayerId} PlayerDeathReason = {PlayerDeathReason} FromPlayerIndex = {FromPlayerIndex} FromNpcIndex = {FromNpcIndex} FromProjectileIndex = {FromProjectileIndex} FromOther = {FromOther} FromProjectileType = {FromProjectileType} FromItemType = {FromItemType} FromItemPrefix = {FromItemPrefix} Damage = {Damage} HitDirection = {HitDirection} Flags = {Flags} CooldownCounter = {CooldownCounter}]";
+        }
+
+        #region implemented abstract members of TerrariaPacket
+
+        public override short GetLength()
+        {
+            return (short)(6 + _length);
+        }
+
+        public override void ToStream(Stream stream, bool includeHeader = true)
+        {
+            /*
              * Length and ID headers get written in the base packet class.
              */
-			if (includeHeader) {
-				base.ToStream(stream, includeHeader);
-			}
+            if (includeHeader) {
+                base.ToStream(stream, includeHeader);
+            }
 
-			/*
+            /*
              * Always make sure to not close the stream when serializing.
              * 
              * It is up to the caller to decide if the underlying stream
@@ -125,23 +163,23 @@ namespace Multiplicity.Packets
              * the regressions of unconditionally closing the TCP socket
              * once the payload of data has been sent to the client.
              */
-			using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
-				br.Write(PlayerId);
-				br.Write(PlayerDeathReason);
-				br.Write(FromPlayerIndex);
-				br.Write(FromNpcIndex);
-				br.Write(FromProjectileIndex);
-				br.Write(FromOther);
-				br.Write(FromProjectileType);
-				br.Write(FromItemType);
-				br.Write(FromItemPrefix);
-				br.Write(Damage);
-				br.Write(HitDirection);
-				br.Write(Flags);
-				br.Write(CooldownCounter);
-			}
-		}
+            using (BinaryWriter br = new BinaryWriter(stream, new System.Text.UTF8Encoding(), leaveOpen: true)) {
+                br.Write(PlayerId);
+                br.Write(PlayerDeathReason);
+                br.Write(FromPlayerIndex);
+                br.Write(FromNpcIndex);
+                br.Write(FromProjectileIndex);
+                br.Write(FromOther);
+                br.Write(FromProjectileType);
+                br.Write(FromItemType);
+                br.Write(FromItemPrefix);
+                br.Write(Damage);
+                br.Write(HitDirection);
+                br.Write(Flags);
+                br.Write(CooldownCounter);
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Multiplicity.Packets/TerrariaPacket.cs
+++ b/Multiplicity.Packets/TerrariaPacket.cs
@@ -4,260 +4,266 @@ using System.IO;
 
 namespace Multiplicity.Packets
 {
-	/// <summary>
-	/// Abstract base class generically representing a terraria packet.
-	/// </summary>
-	public abstract class TerrariaPacket
-	{
-		public const short PACKET_HEADER_LEN = 3;
-		public byte[] TestRawBuffer { get; set; }
+    /// <summary>
+    /// Abstract base class generically representing a terraria packet.
+    /// </summary>
+    public abstract class TerrariaPacket
+    {
+        public const short PACKET_HEADER_LEN = 3;
+        public byte[] TestRawBuffer { get; set; }
 
-		protected short _length = 0;
+        protected short _length = 0;
 
-		/// <summary>
-		/// The deserializer map.
-		/// 
-		/// Deserializer maps point to a function to return a fully qualified packet
-		/// from one supplied BinaryReader object.  Derivatives of TerrariaPacket
-		/// should make sure that they return a valid packet structure when passed a
-		/// BinaryReader to deserialize from.
-		/// </summary>
-		public static Dictionary<PacketTypes, Func<BinaryReader, TerrariaPacket>> deserializerMap = new Dictionary<PacketTypes, Func<BinaryReader, TerrariaPacket>>() {
-			/*001*/ { PacketTypes.ConnectRequest, (br) => new ConnectRequest(br) },
-			/*002*/ { PacketTypes.Disconnect, (br) => new Disconnect(br) },
-			/*003*/ { PacketTypes.ContinueConnecting, (br) => new ContinueConnecting(br) },
-			/*004*/ { PacketTypes.PlayerInfo, (br) => new PlayerInfo(br) },
-			/*005*/ { PacketTypes.PlayerInventorySlot, (br) => new PlayerInventorySlot(br) },
-			/*006*/ { PacketTypes.ContinueConnecting2, (br) => new ContinueConnecting2(br) },
-			/*007*/ { PacketTypes.WorldInfo, (br) => new WorldInfo(br) },
-			/*008*/ { PacketTypes.GetSection, (br) => new GetSection(br) },
-			/*009*/ { PacketTypes.Status, (br) => new Status(br) },
-			/*010*/ { PacketTypes.SendSection, (br) => new SendSection(br) },
-			/*011*/ { PacketTypes.SectionTileFrame, (br) => new SectionTileFrame(br) },
-			/*012*/ { PacketTypes.SpawnPlayer, (br) => new SpawnPlayer(br) },
-			/*013*/ { PacketTypes.UpdatePlayer, (br) => new UpdatePlayer(br) },
-			/*014*/ { PacketTypes.PlayerActive, (br) => new PlayerActive(br) },
-			/*015*/ { PacketTypes.Null, (br) => new Null(br) },
-			/*016*/ { PacketTypes.PlayerHP, (br) => new PlayerHP(br) },
-			/*017*/ { PacketTypes.ModifyTile, (br) => new ModifyTile(br) },
-			/*018*/ { PacketTypes.Time, (br) => new Time(br) },
-			/*019*/ { PacketTypes.DoorToggle, (br) => new DoorToggle(br) },
-			/*020*/ { PacketTypes.SendTileSquare, (br) => new SendTileSquare(br) },
-			/*021*/ { PacketTypes.UpdateItemDrop, (br) => new UpdateItemDrop(br) },
-			/*022*/ { PacketTypes.UpdateItemOwner, (br) => new UpdateItemOwner(br) },
-			/*023*/ { PacketTypes.NPCUpdate, (br) => new NPCUpdate(br) },
-			/*024*/ { PacketTypes.StrikeNPCwithHeldItem, (br) => new StrikeNPCwithHeldItem(br) },
-			/*025*/ { PacketTypes.ChatMessage, (br) => new ChatMessage(br) },
-			/*026*/ { PacketTypes.PlayerDamage, (br) => new PlayerDamage(br) },
-			/*027*/ { PacketTypes.ProjectileUpdate, (br) => new ProjectileUpdate(br) },
-			/*028*/ { PacketTypes.NPCStrike, (br) => new NPCStrike(br) },
-			/*029*/ { PacketTypes.DestroyProjectile, (br) => new DestroyProjectile(br) },
-			/*030*/ { PacketTypes.TogglePVP, (br) => new TogglePVP(br) },
-			/*031*/ { PacketTypes.GetChestContents, (br) => new GetChestContents(br) },
-			/*032*/ { PacketTypes.ChestItem, (br) => new ChestItem(br) },
- 			/*033*/ { PacketTypes.SetChestName, (br) => new SetChestName(br) },
- 			/*034*/ { PacketTypes.PlaceChest, (br) => new PlaceChest(br) },
-			/*035*/ { PacketTypes.HealEffect, (br) => new HealEffect(br) },
-			/*036*/ { PacketTypes.PlayerZone, (br) => new PlayerZone(br) },
-			/*037*/ { PacketTypes.RequestPassword, (br) => new RequestPassword(br) },
-			/*038*/ { PacketTypes.SendPassword, (br) => new SendPassword(br) },
-			/*039*/ { PacketTypes.RemoveItemOwner, (br) => new RemoveItemOwner(br) },
-			/*040*/ { PacketTypes.SetActiveNPC, (br) => new SetActiveNPC(br) },
-			/*041*/ { PacketTypes.PlayerItemAnimation, (br) => new PlayerItemAnimation(br) },
-			/*042*/ { PacketTypes.PlayerMana, (br) => new PlayerMana(br) },
-			/*043*/ { PacketTypes.ManaEffect, (br) => new ManaEffect(br) },
-			/*044*/ { PacketTypes.PlayerDeath, (br) => new PlayerDeath(br) },
-			/*045*/ { PacketTypes.PlayerTeam, (br) => new PlayerTeam(br) },
-			/*046*/ { PacketTypes.RequestSign, (br) => new RequestSign(br) },
-			/*047*/ { PacketTypes.UpdateSign, (br) => new UpdateSign(br) },
-			/*048*/ { PacketTypes.SetLiquid, (br) => new SetLiquid(br) },
-			/*049*/ { PacketTypes.CompleteConnectionandSpawn, (br) => new CompleteConnectionandSpawn(br) },
-			/*050*/ { PacketTypes.UpdatePlayerBuff, (br) => new UpdatePlayerBuff(br) },
-			/*051*/ { PacketTypes.SpecialNPCEffect, (br) => new SpecialNPCEffect(br) },
-			/*052*/ { PacketTypes.Unlock, (br) => new Unlock(br) },
-			/*053*/ { PacketTypes.AddNPCBuff, (br) => new AddNPCBuff(br) },
-			/*054*/ { PacketTypes.UpdateNPCBuff, (br) => new UpdateNPCBuff(br) },
-			/*055*/ { PacketTypes.AddPlayerBuff, (br) => new AddPlayerBuff(br) },
-			/*056*/ { PacketTypes.UpdateNPCName, (br) => new UpdateNPCName(br) },
-			/*057*/ { PacketTypes.UpdateGoodEvil, (br) => new UpdateGoodEvil(br) },
-			/*058*/ { PacketTypes.PlayMusicItem, (br) => new PlayMusicItem(br) },
-			/*059*/ { PacketTypes.HitSwitch, (br) => new HitSwitch(br) },
-			/*060*/ { PacketTypes.NPCHomeUpdate, (br) => new NPCHomeUpdate(br) },
-			/*061*/ { PacketTypes.SpawnBossInvasion, (br) => new SpawnBossInvasion(br) },
-			/*062*/ { PacketTypes.PlayerDodge, (br) => new PlayerDodge(br) },
-			/*063*/ { PacketTypes.PaintTile, (br) => new PaintTile(br) },
-			/*064*/ { PacketTypes.PaintWall, (br) => new PaintWall(br) },
-			/*065*/ { PacketTypes.PlayerNPCTeleport, (br) => new PlayerNPCTeleport(br) },
-			/*066*/ { PacketTypes.HealOtherPlayer, (br) => new HealOtherPlayer(br) },
-			/*067*/ { PacketTypes.Placeholder, (br) => new Placeholder(br) },
-			/*068*/ { PacketTypes.ClientUUID, (br) => new ClientUUID(br) },
-			/*069*/ { PacketTypes.GetChestName, (br) => new GetChestName(br) },
-			/*070*/ { PacketTypes.CatchNPC, (br) => new CatchNPC(br) },
-			/*071*/ { PacketTypes.ReleaseNPC, (br) => new ReleaseNPC(br) },
-			/*072*/ { PacketTypes.TravellingMerchantInventory, (br) => new TravellingMerchantInventory(br) },
-			/*073*/ { PacketTypes.TeleportationPotion, (br) => new TeleportationPotion(br) },
-			/*074*/ { PacketTypes.AnglerQuest, (br) => new AnglerQuest(br) },
-			/*075*/ { PacketTypes.CompleteAnglerQuestToday, (br) => new CompleteAnglerQuestToday(br) },
-			/*076*/ { PacketTypes.NumberOfAnglerQuestsCompleted, (br) => new NumberOfAnglerQuestsCompleted(br) },
-			/*077*/ { PacketTypes.CreateTemporaryAnimation, (br) => new CreateTemporaryAnimation(br) },
-			/*078*/ { PacketTypes.ReportInvasionProgress, (br) => new ReportInvasionProgress(br) },
-			/*079*/ { PacketTypes.PlaceObject, (br) => new PlaceObject(br) },
-			/*080*/ { PacketTypes.SyncPlayerChestIndex, (br) => new SyncPlayerChestIndex(br) },
-			/*081*/ { PacketTypes.CreateCombatText, (br) => new CreateCombatText(br) },
-			/*082*/ { PacketTypes.LoadNetModule, (br) => new LoadNetModule(br) },
-			/*083*/ { PacketTypes.SetNPCKillCount, (br) => new SetNPCKillCount(br) },
-			/*084*/ { PacketTypes.SetPlayerStealth, (br) => new SetPlayerStealth(br) },
-			/*085*/ { PacketTypes.ForceItemIntoNearestChest, (br) => new ForceItemIntoNearestChest(br) },
-			/*086*/ { PacketTypes.UpdateTileEntity, (br) => new UpdateTileEntity(br) },
-			/*087*/ { PacketTypes.PlaceTileEntity, (br) => new PlaceTileEntity(br) },
-			/*088*/ { PacketTypes.AlterItemDrop, (br) => new AlterItemDrop(br) },
-			/*089*/ { PacketTypes.PlaceItemFrame, (br) => new PlaceItemFrame(br) },
-			/*090*/ { PacketTypes.UpdateItemDrop2, (br) => new UpdateItemDrop2(br) },
-			/*091*/ { PacketTypes.SyncEmoteBubble, (br) => new SyncEmoteBubble(br) },
-			/*092*/ { PacketTypes.SyncExtraValue, (br) => new SyncExtraValue(br) },
-			/*093*/ { PacketTypes.SocialHandshake, (br) => new SocialHandshake(br) },
-			/*094*/ { PacketTypes.Deprecated, (br) => new Deprecated(br) },
-			/*095*/ { PacketTypes.KillPortal, (br) => new KillPortal(br) },
-			/*096*/ { PacketTypes.PlayerTeleportThroughPortal, (br) => new PlayerTeleportThroughPortal(br) },
-			/*097*/ { PacketTypes.NotifyPlayerNPCKilled, (br) => new NotifyPlayerNPCKilled(br) },
-			/*098*/ { PacketTypes.NotifyPlayerOfEvent, (br) => new NotifyPlayerOfEvent(br) },
-			/*099*/ { PacketTypes.UpdateMinionTarget, (br) => new UpdateMinionTarget(br) },
-			/*100*/ { PacketTypes.NPCTeleportThroughPortal, (br) => new NPCTeleportThroughPortal(br) },
-			/*101*/ { PacketTypes.UpdateShieldStrengths, (br) => new UpdateShieldStrengths(br) },
-			/*102*/ { PacketTypes.NebulaLevelUpRequest, (br) => new NebulaLevelUpRequest(br) },
-			/*103*/ { PacketTypes.UpdateMoonLordCountdown, (br) => new UpdateMoonLordCountdown(br) },
-			/*104*/ { PacketTypes.SetNPCShopItem, (br) => new SetNPCShopItem(br) },
-			/*105*/ { PacketTypes.ToggleGemLock, (br) => new ToggleGemLock(br) },
-			/*106*/ { PacketTypes.PoofofSmoke, (br) => new PoofofSmoke(br) },
-			/*107*/ { PacketTypes.ChatMessagev2, (br) => new ChatMessagev2(br) },
-			/*108*/ { PacketTypes.WiredCannonShot, (br) => new WiredCannonShot(br) },
-			/*109*/ { PacketTypes.MassWireOperation, (br) => new MassWireOperation(br) },
-			/*110*/ { PacketTypes.MassWireOperationConsume, (br) => new MassWireOperationConsume(br) },
-			/*111*/ { PacketTypes.ToggleBirthdayParty, (br) => new ToggleBirthdayParty(br) },
-			/*112*/ { PacketTypes.GrowFX, (br) => new GrowFX(br) }
-		};
+        /// <summary>
+        /// The deserializer map.
+        /// 
+        /// Deserializer maps point to a function to return a fully qualified packet
+        /// from one supplied BinaryReader object.  Derivatives of TerrariaPacket
+        /// should make sure that they return a valid packet structure when passed a
+        /// BinaryReader to deserialize from.
+        /// </summary>
+        public static Dictionary<PacketTypes, Func<BinaryReader, TerrariaPacket>> deserializerMap = new Dictionary<PacketTypes, Func<BinaryReader, TerrariaPacket>>() {
+            /*001*/ { PacketTypes.ConnectRequest, (br) => new ConnectRequest(br) },
+            /*002*/ { PacketTypes.Disconnect, (br) => new Disconnect(br) },
+            /*003*/ { PacketTypes.ContinueConnecting, (br) => new ContinueConnecting(br) },
+            /*004*/ { PacketTypes.PlayerInfo, (br) => new PlayerInfo(br) },
+            /*005*/ { PacketTypes.PlayerInventorySlot, (br) => new PlayerInventorySlot(br) },
+            /*006*/ { PacketTypes.ContinueConnecting2, (br) => new ContinueConnecting2(br) },
+            /*007*/ { PacketTypes.WorldInfo, (br) => new WorldInfo(br) },
+            /*008*/ { PacketTypes.GetSection, (br) => new GetSection(br) },
+            /*009*/ { PacketTypes.Status, (br) => new Status(br) },
+            /*010*/ { PacketTypes.SendSection, (br) => new SendSection(br) },
+            /*011*/ { PacketTypes.SectionTileFrame, (br) => new SectionTileFrame(br) },
+            /*012*/ { PacketTypes.SpawnPlayer, (br) => new SpawnPlayer(br) },
+            /*013*/ { PacketTypes.UpdatePlayer, (br) => new UpdatePlayer(br) },
+            /*014*/ { PacketTypes.PlayerActive, (br) => new PlayerActive(br) },
+            /*015*/ { PacketTypes.Null, (br) => new Null(br) },
+            /*016*/ { PacketTypes.PlayerHP, (br) => new PlayerHP(br) },
+            /*017*/ { PacketTypes.ModifyTile, (br) => new ModifyTile(br) },
+            /*018*/ { PacketTypes.Time, (br) => new Time(br) },
+            /*019*/ { PacketTypes.DoorToggle, (br) => new DoorToggle(br) },
+            /*020*/ { PacketTypes.SendTileSquare, (br) => new SendTileSquare(br) },
+            /*021*/ { PacketTypes.UpdateItemDrop, (br) => new UpdateItemDrop(br) },
+            /*022*/ { PacketTypes.UpdateItemOwner, (br) => new UpdateItemOwner(br) },
+            /*023*/ { PacketTypes.NPCUpdate, (br) => new NPCUpdate(br) },
+            /*024*/ { PacketTypes.StrikeNPCwithHeldItem, (br) => new StrikeNPCwithHeldItem(br) },
+            /*025*/ { PacketTypes.ChatMessage, (br) => new ChatMessage(br) },
+            /*026*/ { PacketTypes.PlayerDamage, (br) => new PlayerDamage(br) },
+            /*027*/ { PacketTypes.ProjectileUpdate, (br) => new ProjectileUpdate(br) },
+            /*028*/ { PacketTypes.NPCStrike, (br) => new NPCStrike(br) },
+            /*029*/ { PacketTypes.DestroyProjectile, (br) => new DestroyProjectile(br) },
+            /*030*/ { PacketTypes.TogglePVP, (br) => new TogglePVP(br) },
+            /*031*/ { PacketTypes.GetChestContents, (br) => new GetChestContents(br) },
+            /*032*/ { PacketTypes.ChestItem, (br) => new ChestItem(br) },
+            /*033*/ { PacketTypes.SetChestName, (br) => new SetChestName(br) },
+            /*034*/ { PacketTypes.PlaceChest, (br) => new PlaceChest(br) },
+            /*035*/ { PacketTypes.HealEffect, (br) => new HealEffect(br) },
+            /*036*/ { PacketTypes.PlayerZone, (br) => new PlayerZone(br) },
+            /*037*/ { PacketTypes.RequestPassword, (br) => new RequestPassword(br) },
+            /*038*/ { PacketTypes.SendPassword, (br) => new SendPassword(br) },
+            /*039*/ { PacketTypes.RemoveItemOwner, (br) => new RemoveItemOwner(br) },
+            /*040*/ { PacketTypes.SetActiveNPC, (br) => new SetActiveNPC(br) },
+            /*041*/ { PacketTypes.PlayerItemAnimation, (br) => new PlayerItemAnimation(br) },
+            /*042*/ { PacketTypes.PlayerMana, (br) => new PlayerMana(br) },
+            /*043*/ { PacketTypes.ManaEffect, (br) => new ManaEffect(br) },
+            /*044*/ { PacketTypes.PlayerDeath, (br) => new PlayerDeath(br) },
+            /*045*/ { PacketTypes.PlayerTeam, (br) => new PlayerTeam(br) },
+            /*046*/ { PacketTypes.RequestSign, (br) => new RequestSign(br) },
+            /*047*/ { PacketTypes.UpdateSign, (br) => new UpdateSign(br) },
+            /*048*/ { PacketTypes.SetLiquid, (br) => new SetLiquid(br) },
+            /*049*/ { PacketTypes.CompleteConnectionandSpawn, (br) => new CompleteConnectionandSpawn(br) },
+            /*050*/ { PacketTypes.UpdatePlayerBuff, (br) => new UpdatePlayerBuff(br) },
+            /*051*/ { PacketTypes.SpecialNPCEffect, (br) => new SpecialNPCEffect(br) },
+            /*052*/ { PacketTypes.Unlock, (br) => new Unlock(br) },
+            /*053*/ { PacketTypes.AddNPCBuff, (br) => new AddNPCBuff(br) },
+            /*054*/ { PacketTypes.UpdateNPCBuff, (br) => new UpdateNPCBuff(br) },
+            /*055*/ { PacketTypes.AddPlayerBuff, (br) => new AddPlayerBuff(br) },
+            /*056*/ { PacketTypes.UpdateNPCName, (br) => new UpdateNPCName(br) },
+            /*057*/ { PacketTypes.UpdateGoodEvil, (br) => new UpdateGoodEvil(br) },
+            /*058*/ { PacketTypes.PlayMusicItem, (br) => new PlayMusicItem(br) },
+            /*059*/ { PacketTypes.HitSwitch, (br) => new HitSwitch(br) },
+            /*060*/ { PacketTypes.NPCHomeUpdate, (br) => new NPCHomeUpdate(br) },
+            /*061*/ { PacketTypes.SpawnBossInvasion, (br) => new SpawnBossInvasion(br) },
+            /*062*/ { PacketTypes.PlayerDodge, (br) => new PlayerDodge(br) },
+            /*063*/ { PacketTypes.PaintTile, (br) => new PaintTile(br) },
+            /*064*/ { PacketTypes.PaintWall, (br) => new PaintWall(br) },
+            /*065*/ { PacketTypes.PlayerNPCTeleport, (br) => new PlayerNPCTeleport(br) },
+            /*066*/ { PacketTypes.HealOtherPlayer, (br) => new HealOtherPlayer(br) },
+            /*067*/ { PacketTypes.Placeholder, (br) => new Placeholder(br) },
+            /*068*/ { PacketTypes.ClientUUID, (br) => new ClientUUID(br) },
+            /*069*/ { PacketTypes.GetChestName, (br) => new GetChestName(br) },
+            /*070*/ { PacketTypes.CatchNPC, (br) => new CatchNPC(br) },
+            /*071*/ { PacketTypes.ReleaseNPC, (br) => new ReleaseNPC(br) },
+            /*072*/ { PacketTypes.TravellingMerchantInventory, (br) => new TravellingMerchantInventory(br) },
+            /*073*/ { PacketTypes.TeleportationPotion, (br) => new TeleportationPotion(br) },
+            /*074*/ { PacketTypes.AnglerQuest, (br) => new AnglerQuest(br) },
+            /*075*/ { PacketTypes.CompleteAnglerQuestToday, (br) => new CompleteAnglerQuestToday(br) },
+            /*076*/ { PacketTypes.NumberOfAnglerQuestsCompleted, (br) => new NumberOfAnglerQuestsCompleted(br) },
+            /*077*/ { PacketTypes.CreateTemporaryAnimation, (br) => new CreateTemporaryAnimation(br) },
+            /*078*/ { PacketTypes.ReportInvasionProgress, (br) => new ReportInvasionProgress(br) },
+            /*079*/ { PacketTypes.PlaceObject, (br) => new PlaceObject(br) },
+            /*080*/ { PacketTypes.SyncPlayerChestIndex, (br) => new SyncPlayerChestIndex(br) },
+            /*081*/ { PacketTypes.CreateCombatText, (br) => new CreateCombatText(br) },
+            /*082*/ { PacketTypes.LoadNetModule, (br) => new LoadNetModule(br) },
+            /*083*/ { PacketTypes.SetNPCKillCount, (br) => new SetNPCKillCount(br) },
+            /*084*/ { PacketTypes.SetPlayerStealth, (br) => new SetPlayerStealth(br) },
+            /*085*/ { PacketTypes.ForceItemIntoNearestChest, (br) => new ForceItemIntoNearestChest(br) },
+            /*086*/ { PacketTypes.UpdateTileEntity, (br) => new UpdateTileEntity(br) },
+            /*087*/ { PacketTypes.PlaceTileEntity, (br) => new PlaceTileEntity(br) },
+            /*088*/ { PacketTypes.AlterItemDrop, (br) => new AlterItemDrop(br) },
+            /*089*/ { PacketTypes.PlaceItemFrame, (br) => new PlaceItemFrame(br) },
+            /*090*/ { PacketTypes.UpdateItemDrop2, (br) => new UpdateItemDrop2(br) },
+            /*091*/ { PacketTypes.SyncEmoteBubble, (br) => new SyncEmoteBubble(br) },
+            /*092*/ { PacketTypes.SyncExtraValue, (br) => new SyncExtraValue(br) },
+            /*093*/ { PacketTypes.SocialHandshake, (br) => new SocialHandshake(br) },
+            /*094*/ { PacketTypes.Deprecated, (br) => new Deprecated(br) },
+            /*095*/ { PacketTypes.KillPortal, (br) => new KillPortal(br) },
+            /*096*/ { PacketTypes.PlayerTeleportThroughPortal, (br) => new PlayerTeleportThroughPortal(br) },
+            /*097*/ { PacketTypes.NotifyPlayerNPCKilled, (br) => new NotifyPlayerNPCKilled(br) },
+            /*098*/ { PacketTypes.NotifyPlayerOfEvent, (br) => new NotifyPlayerOfEvent(br) },
+            /*099*/ { PacketTypes.UpdateMinionTarget, (br) => new UpdateMinionTarget(br) },
+            /*100*/ { PacketTypes.NPCTeleportThroughPortal, (br) => new NPCTeleportThroughPortal(br) },
+            /*101*/ { PacketTypes.UpdateShieldStrengths, (br) => new UpdateShieldStrengths(br) },
+            /*102*/ { PacketTypes.NebulaLevelUpRequest, (br) => new NebulaLevelUpRequest(br) },
+            /*103*/ { PacketTypes.UpdateMoonLordCountdown, (br) => new UpdateMoonLordCountdown(br) },
+            /*104*/ { PacketTypes.SetNPCShopItem, (br) => new SetNPCShopItem(br) },
+            /*105*/ { PacketTypes.ToggleGemLock, (br) => new ToggleGemLock(br) },
+            /*106*/ { PacketTypes.PoofofSmoke, (br) => new PoofofSmoke(br) },
+            /*107*/ { PacketTypes.ChatMessagev2, (br) => new ChatMessagev2(br) },
+            /*108*/ { PacketTypes.WiredCannonShot, (br) => new WiredCannonShot(br) },
+            /*109*/ { PacketTypes.MassWireOperation, (br) => new MassWireOperation(br) },
+            /*110*/ { PacketTypes.MassWireOperationConsume, (br) => new MassWireOperationConsume(br) },
+            /*111*/ { PacketTypes.ToggleBirthdayParty, (br) => new ToggleBirthdayParty(br) },
+            /*112*/ { PacketTypes.GrowFX, (br) => new GrowFX(br) },
+            /*113*/ { PacketTypes.CrystalInvasionStart, (br) => new CrystalInvasionStart(br) },
+            /*114*/ { PacketTypes.CrystalInvasionWipeAll, (br) => new CrystalInvasionWipeAll(br) },
+            /*115*/ { PacketTypes.MinionAttackTargetUpdate, (br) => new MinionAttackTargetUpdate(br) },
+            /*116*/ { PacketTypes.CrystalInvasionSendWaitTime, (br) => new CrystalInvasionSendWaitTime(br) },
+            /*117*/ { PacketTypes.PlayerHurtV2, (br) => new PlayerHurtV2(br) },
+            /*118*/ { PacketTypes.PlayerDeathV2, (br) => new PlayerDeathV2(br) }
+        };
 
-		/// <summary>
-		/// Gets the packet length in bytes.
-		/// </summary>
-		public abstract short GetLength();
+        /// <summary>
+        /// Gets the packet length in bytes.
+        /// </summary>
+        public abstract short GetLength();
 
-		/// <summary>
-		/// Gets or sets the Packet ID.
-		/// </summary>
-		public byte ID { get; protected set; }
+        /// <summary>
+        /// Gets or sets the Packet ID.
+        /// </summary>
+        public byte ID { get; protected set; }
 
-		/// <summary>
-		/// Gets the type of the packet.
-		/// </summary>
-		public PacketTypes PacketType
-		{
-			get
-			{
-				return (PacketTypes)this.ID;
-			}
-		}
+        /// <summary>
+        /// Gets the type of the packet.
+        /// </summary>
+        public PacketTypes PacketType
+        {
+            get
+            {
+                return (PacketTypes)this.ID;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the CRC32 hash for this TerrariaPacket.
-		/// </summary>
-		/// <value>The CRC.</value>
-		public uint CRC { get; internal set; }
+        /// <summary>
+        /// Gets or sets the CRC32 hash for this TerrariaPacket.
+        /// </summary>
+        /// <value>The CRC.</value>
+        public uint CRC { get; internal set; }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="TerrariaPacket"/> with 
-		/// the specified BinaryReader object to deserialize a derivative on.
-		/// </summary>
-		/// <param name="br">
-		/// A reference to a BinaryReader which contains binary payload to be deserialized into
-		/// a fully-qualified TerrariaPacket.
-		/// </param>
-		protected TerrariaPacket(BinaryReader br)
-		{
-			_length = br.ReadInt16();
-			this.ID = br.ReadByte();
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TerrariaPacket"/> with 
+        /// the specified BinaryReader object to deserialize a derivative on.
+        /// </summary>
+        /// <param name="br">
+        /// A reference to a BinaryReader which contains binary payload to be deserialized into
+        /// a fully-qualified TerrariaPacket.
+        /// </param>
+        protected TerrariaPacket(BinaryReader br)
+        {
+            _length = br.ReadInt16();
+            this.ID = br.ReadByte();
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="TerrariaPacket"/> class.
-		/// </summary>
-		/// <param name="id">Identifier.</param>
-		protected TerrariaPacket(byte id)
-		{
-			this.ID = id;
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TerrariaPacket"/> class.
+        /// </summary>
+        /// <param name="id">Identifier.</param>
+        protected TerrariaPacket(byte id)
+        {
+            this.ID = id;
+        }
 
-		/// <summary>
-		/// Deserializes a packet from the specified binary reader and returns a TerrariaPacket 
-		/// derivative according to the deserializer methods in deserializerMap.
-		/// </summary>
-		/// <param name="br">
-		/// An instance of a BinaryReader which contains a binary terraria packet payload in 
-		/// which to deserialize an object from
-		/// </param>
-		/// <param name="id">
-		/// Packet identifier that is used to find the deserializer method via deserializerMap
-		/// </param>
-		public static TerrariaPacket Deserialize(BinaryReader br, byte id)
-		{
-			br.BaseStream.Seek(0, SeekOrigin.Begin);
+        /// <summary>
+        /// Deserializes a packet from the specified binary reader and returns a TerrariaPacket 
+        /// derivative according to the deserializer methods in deserializerMap.
+        /// </summary>
+        /// <param name="br">
+        /// An instance of a BinaryReader which contains a binary terraria packet payload in 
+        /// which to deserialize an object from
+        /// </param>
+        /// <param name="id">
+        /// Packet identifier that is used to find the deserializer method via deserializerMap
+        /// </param>
+        public static TerrariaPacket Deserialize(BinaryReader br, byte id)
+        {
+            br.BaseStream.Seek(0, SeekOrigin.Begin);
 
-			if (deserializerMap.ContainsKey((PacketTypes)id) == false)
-			{
-				return new UnknownPacket(br);
-			}
+            if (deserializerMap.ContainsKey((PacketTypes)id) == false)
+            {
+                return new UnknownPacket(br);
+            }
 
-			return deserializerMap[(PacketTypes)id](br);
-		}
+            return deserializerMap[(PacketTypes)id](br);
+        }
 
-		/// <summary>
-		/// Deserializes a packet from the specified binary reader and returns a TerrariaPacket 
-		/// derivative according to the deserializer methods in deserializerMap.
-		/// </summary>
-		/// <param name="br">
-		/// An instance of a BinaryReader which contains a binary terraria packet payload in 
-		/// which to deserialize an object from
-		/// </param>
-		public static TerrariaPacket Deserialize(BinaryReader br)
-		{
-			br.ReadInt16();
-			byte id = br.ReadByte();
+        /// <summary>
+        /// Deserializes a packet from the specified binary reader and returns a TerrariaPacket 
+        /// derivative according to the deserializer methods in deserializerMap.
+        /// </summary>
+        /// <param name="br">
+        /// An instance of a BinaryReader which contains a binary terraria packet payload in 
+        /// which to deserialize an object from
+        /// </param>
+        public static TerrariaPacket Deserialize(BinaryReader br)
+        {
+            br.ReadInt16();
+            byte id = br.ReadByte();
 
-			return Deserialize(br, id);
-		}
+            return Deserialize(br, id);
+        }
 
-		/// <summary>
-		/// Serializes this TerrariaPacket instance into the provided stream.
-		/// </summary>
-		/// <param name="stream">
-		/// A reference to a valid, open, and writable stream object in which to serialize this
-		/// instance to.
-		/// </param>
-		public virtual void ToStream(Stream stream, bool includeHeader = true)
-		{
-			if (includeHeader == false)
-			{
-				return;
-			}
+        /// <summary>
+        /// Serializes this TerrariaPacket instance into the provided stream.
+        /// </summary>
+        /// <param name="stream">
+        /// A reference to a valid, open, and writable stream object in which to serialize this
+        /// instance to.
+        /// </param>
+        public virtual void ToStream(Stream stream, bool includeHeader = true)
+        {
+            if (includeHeader == false)
+            {
+                return;
+            }
 
-			using (BinaryWriter br = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
-			{
-				br.Write((short)(GetLength() + PACKET_HEADER_LEN));
-				br.Write(ID);
-			}
-		}
+            using (BinaryWriter br = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                br.Write((short)(GetLength() + PACKET_HEADER_LEN));
+                br.Write(ID);
+            }
+        }
 
-		/// <summary>
-		/// Returns a byte array with the binary contents of this TerrariaPacket instance.
-		/// </summary>
-		public virtual byte[] ToArray(bool includeHeader = true)
-		{
-			using (MemoryStream ms = new MemoryStream())
-			{
-				ToStream(ms, includeHeader);
-				return ms.ToArray();
-			}
-		}
-	}
+        /// <summary>
+        /// Returns a byte array with the binary contents of this TerrariaPacket instance.
+        /// </summary>
+        public virtual byte[] ToArray(bool includeHeader = true)
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ToStream(ms, includeHeader);
+                return ms.ToArray();
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
Includes the following packets: 

- CrystalInvaionStart

- CrystalInvasionWipeAll

- MinionAttackTargetUpdate

- CrystalInvasionSendWaitTime

- PlayerHurtV2

- PlayerDeathV2

Due to the nature of Terraria's player death packets it requires a slight workaround in order to read the packets properly, thus I added a ByteExtensions class to be able to read the byte's bits.